### PR TITLE
fix plugin-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ can run `git pull` yourself, or even use a simple `plugin-update` function:
 
 ```zsh
 function plugin-update () {
-  ZPLUGINDIR=${ZPLUGINDIR:~/.config/zsh/plugins}
+  ZPLUGINDIR=${ZPLUGINDIR:-$HOME/.config/zsh/plugins}
   for d in $ZPLUGINDIR/*/.git(/); do
     echo "Updating ${d:h:t}..."
     command git -C "${d:h}" pull --ff --recurse-submodules --depth 1 --rebase --autostash


### PR DESCRIPTION
the current plugin-update function will cause the following error:
`zsh: bad math expression: operand expected at `/.config/z...'`