### PR TITLE
fix sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ ZPLUGINDIR=${ZPLUGINDIR:-${ZDOTDIR:-$HOME/.config/zsh}/plugins}
 if [[ ! -d $ZPLUGINDIR/zsh_unplugged ]]; then
   git clone --quiet https://github.com/mattmc3/zsh_unplugged $ZPLUGINDIR/zsh_unplugged
 fi
-source $ZPLUGINDIR/zsh_unplugged/zsh_unplugged.plugin.zsh
+source $ZPLUGINDIR/zsh_unplugged/zsh_unplugged.zsh
 
 # make list of the Zsh plugins you use
 repos=(


### PR DESCRIPTION
@mattmc3 updated the filename zsh_unplugged.plugin.zsh to zsh_unplugged.zsh, which breaks the readme instructions.
This should fix it.