### PR TITLE
Fill out stats of zr

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here's a list of many (but certainly not all) of them from [awesome-zsh-plugins]
 | [zplug]            | :turtle: slow      | :skull_and_crossbones: Abandonware              |
 | [zplugin][zinit]   | :rabbit2: fast     | :cursing_face: Renamed to zinit, author deleted |
 | [zpm]              | :rabbit2: fast     | :white_check_mark: Active                       |
-| [zr]               | :question: unknown | :imp: Few/no recent commits                     |
+| [zr]               | :rabbit2: fast     | :imp: Complete, bugfixes welcome                |
 
 _Full disclosure, I'm the author of one of these - [antidote] (formerly called [pz])._
 


### PR DESCRIPTION
o/

Not sure why performance was unknown, I posted [reproducible benchmarks](https://github.com/jedahan/zr?tab=readme-ov-file#speed) in the readme

zr essentially does the same thing as plugin-load does, except it support any uri that git supports, and lets you 'update' them by doing `git pull`

i think it is very similar to your load-plugin philosophy

```zsh
 ▲ zr zsh-users/zsh-autosuggestions
export _ZR=$0 # used for zr --update
# zsh-users/zsh-autosuggestions
source /Users/micro/Library/Caches/zr/zsh-users/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
PATH=/Users/micro/Library/Caches/zr/zsh-users/zsh-autosuggestions:$PATH
fpath+=/Users/micro/Library/Caches/zr/zsh-users/zsh-autosuggestions/
```
